### PR TITLE
Remove chart.js version number constraint

### DIFF
--- a/power-usage-card-regex.js
+++ b/power-usage-card-regex.js
@@ -1,4 +1,4 @@
-import "https://unpkg.com/chart.js@2.7.1/dist/Chart.bundle.min.js?module";
+import "https://unpkg.com/chart.js/dist/Chart.bundle.min.js?module";
 import "https://cdn.jsdelivr.net/npm/chartjs-plugin-colorschemes";
 
 class PowerUsageCardRE extends HTMLElement {


### PR DESCRIPTION
I had the same problems with no colors in the chart and the size bouncing up and down on cursor hover. Removing the constraint to a very old version of chart.js fixed both issues.